### PR TITLE
Rep 3343 add grid no agent to energy valley

### DIFF
--- a/src/marloes/agents/grid.py
+++ b/src/marloes/agents/grid.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from simon.assets.grid import Connection
+
+
+class GridAgent:
+    """
+    GridAgent is an agent that represents the Grid.
+    config would require:
+    - name: name of the agent
+    - max_power_in: maximum power that can be drawn from the grid
+    - max_power_out: maximum power that can be fed back to the grid
+    """
+
+    def __init__(self, config: dict, start_time: datetime):
+        self.asset = Connection(config, start_time)
+
+    def get_state(self):
+        """
+        Returns the current state of the 'Connection' asset from Simon
+        This is an AssetState with 'time' and 'power'
+        """
+        return self.asset.state

--- a/src/marloes/agents/grid.py
+++ b/src/marloes/agents/grid.py
@@ -1,23 +1,39 @@
 from datetime import datetime
-
+import numpy as np
 from simon.assets.grid import Connection
 
 
 class GridAgent:
     """
     GridAgent is an agent that represents the Grid.
-    config would require:
+    config requires:
     - name: name of the agent
     - max_power_in: maximum power that can be drawn from the grid
     - max_power_out: maximum power that can be fed back to the grid
     """
 
     def __init__(self, config: dict, start_time: datetime):
-        self.asset = Connection(config, start_time)
+        self.asset = Connection(
+            **self._merge_configs(self._get_default_grid_config(), config)
+        )
+        self.asset.load_default_state(start_time)
 
     def get_state(self):
         """
-        Returns the current state of the 'Connection' asset from Simon
-        This is an AssetState with 'time' and 'power'
+        Returns the current state of the 'Connection' asset from Simon.
+        This is an AssetState with 'time' and 'power'.
         """
         return self.asset.state
+
+    @classmethod
+    def _get_default_grid_config(cls) -> dict:
+        return {
+            "name": "Grid",
+            "max_power_in": np.inf,
+            "max_power_out": np.inf,
+        }
+
+    @staticmethod
+    def _merge_configs(default_config: dict, config: dict) -> dict:
+        """Merge the default configuration with user-provided values."""
+        return {**default_config, **config}

--- a/src/marloes/simulation.py
+++ b/src/marloes/simulation.py
@@ -1,5 +1,3 @@
-from abc import ABC, abstractmethod
-import pandas as pd
 from .valley.env import EnergyValley
 import random
 

--- a/src/marloes/valley/env.py
+++ b/src/marloes/valley/env.py
@@ -8,28 +8,34 @@ from marloes.agents.electrolyser import ElectrolyserAgent
 from marloes.agents.demand import DemandAgent
 from marloes.agents.solar import SolarAgent
 from marloes.agents.wind import WindAgent
+from marloes.agents.grid import GridAgent
 
 
 class EnergyValley:
     def __init__(self, config: dict):
+        self.start_time = datetime(2025, 1, 1, tzinfo=ZoneInfo("UTC"))
         self.agents = []
         [self.add_agent(agent_config) for agent_config in config["agents"]]
+        """Initialize the GridAgent with the given configuration, or default if not provided"""
+        self.agents.append(
+            GridAgent(config=config.get("grid", {}), start_time=self.start_time)
+        )
+
         # TODO: handle other config parameters, include in testing
 
     def add_agent(self, agent_config: dict):
         # Start time is fixed at 2025-01-01
-        start_time = datetime(2025, 1, 1, tzinfo=ZoneInfo("UTC"))
         match agent_config.pop("type"):
             case "battery":
-                agent = BatteryAgent(agent_config, start_time)
+                agent = BatteryAgent(agent_config, self.start_time)
             case "electrolyser":
-                agent = ElectrolyserAgent(agent_config, start_time)
+                agent = ElectrolyserAgent(agent_config, self.start_time)
             case "demand":
-                agent = DemandAgent(agent_config, start_time)
+                agent = DemandAgent(agent_config, self.start_time)
             case "solar":
-                agent = SolarAgent(agent_config, start_time)
+                agent = SolarAgent(agent_config, self.start_time)
             case "wind":
-                agent = WindAgent(agent_config, start_time)
+                agent = WindAgent(agent_config, self.start_time)
         self.agents.append(agent)
         # add to self.agents with necessary priorities, edges or constraints
 

--- a/test/agents/test_grid.py
+++ b/test/agents/test_grid.py
@@ -1,0 +1,38 @@
+import unittest
+from freezegun import freeze_time
+from datetime import datetime
+from simon.assets.grid import Connection
+from marloes.agents.grid import GridAgent
+
+
+@freeze_time("2023-01-01 12:00:00")
+class TestGridAgent(unittest.TestCase):
+    def setUp(self) -> None:
+        self.grid_agent = GridAgent(config={}, start_time=datetime.now())
+
+    def test_init(self):
+        self.assertIsInstance(self.grid_agent.asset, Connection)
+        self.assertEqual(self.grid_agent.asset.name, "Grid")
+        self.assertEqual(self.grid_agent.asset.max_power_in, float("inf"))
+        self.assertEqual(self.grid_agent.asset.max_power_out, float("inf"))
+        # test the initial (default) state
+        self.assertEqual(self.grid_agent.asset.state.time, datetime.now())
+        self.assertEqual(self.grid_agent.asset.state.power, 0.0)
+
+    def test_partial_init(self):
+        partial_config = {
+            "max_power_in": 100.0,
+        }
+        self.grid_agent = GridAgent(config=partial_config, start_time=datetime.now())
+        self.assertIsInstance(self.grid_agent.asset, Connection)
+        self.assertEqual(self.grid_agent.asset.name, "Grid")
+        self.assertEqual(self.grid_agent.asset.max_power_in, 100.0)
+        self.assertEqual(self.grid_agent.asset.max_power_out, float("inf"))
+        # test the initial (default) state
+        self.assertEqual(self.grid_agent.asset.state.time, datetime.now())
+        self.assertEqual(self.grid_agent.asset.state.power, 0.0)
+
+    def test_get_state(self):
+        state = self.grid_agent.get_state()
+        self.assertEqual(state.time, datetime.now())
+        self.assertEqual(state.power, 0.0)

--- a/test/test_simulation.py
+++ b/test/test_simulation.py
@@ -32,6 +32,7 @@ def get_new_config():  # function to return a new configuration, pop caused issu
                 "max_power_out": 100,
             },
         ],
+        # no grid agent should default to name="Grid", max_power_in and max_power_out should be inf
     }
 
 
@@ -47,10 +48,30 @@ class TestSimulation(unittest.TestCase):
     def test_init(self):
         # no saving
         self.assertEqual(self.sim.epochs, 100)
-        self.assertEqual(len(self.sim.valley.agents), 3)
+        self.assertEqual(len(self.sim.valley.agents), 4)
         self.assertFalse(self.sim.saving)
         self.assertIsNone(self.sim.flows, None)
         self.assertEqual(self.sim.algorithm, AlgorithmType.MODEL_BASED)
         # saving
         self.assertTrue(self.sim_saving.saving)
         self.assertIsInstance(self.sim_saving.flows, list)
+
+    def test_agent_types(self):
+        # check if the agents are of the right type
+        self.assertEqual(len(self.sim.valley.agents), 4)
+        self.assertEqual(len(self.sim_saving.valley.agents), 4)
+        self.assertEqual(
+            [agent.__class__.__name__ for agent in self.sim.valley.agents],
+            ["DemandAgent", "SolarAgent", "BatteryAgent", "GridAgent"],
+        )
+        self.assertEqual(
+            [agent.__class__.__name__ for agent in self.sim_saving.valley.agents],
+            ["DemandAgent", "SolarAgent", "BatteryAgent", "GridAgent"],
+        )
+
+    def test_grid(self):
+        # check if the grid agent is correctly initialized (default)
+        grid = self.sim.valley.agents[-1]
+        self.assertEqual(grid.asset.name, "Grid")
+        self.assertEqual(grid.asset.max_power_in, float("inf"))
+        self.assertEqual(grid.asset.max_power_out, float("inf"))

--- a/test/valley/test_env.py
+++ b/test/valley/test_env.py
@@ -5,6 +5,7 @@ import pandas as pd
 from marloes.agents.demand import DemandAgent
 from marloes.agents.solar import SolarAgent
 from marloes.agents.battery import BatteryAgent
+from marloes.agents.grid import GridAgent
 from marloes.valley.env import EnergyValley
 
 
@@ -30,6 +31,10 @@ def get_new_config():  # function to return a new configuration, pop caused issu
                 "energy_capacity": 1000,
             },
         ],
+        "grid": {
+            "name": "Grid_One",
+            "max_power_in": 1000,
+        },
     }
 
 
@@ -40,11 +45,12 @@ class TestEnergyValleyEnv(unittest.TestCase):
             self.env = EnergyValley(config=get_new_config())
 
     def test_init(self):
-        self.assertEqual(len(self.env.agents), 3)
+        self.assertEqual(len(self.env.agents), 4)  # 3 agents + 1 grid
         # check if the agents are of the right type
         self.assertIsInstance(self.env.agents[0], DemandAgent)
         self.assertIsInstance(self.env.agents[1], SolarAgent)
         self.assertIsInstance(self.env.agents[2], BatteryAgent)
+        self.assertIsInstance(self.env.agents[3], GridAgent)
         # check start time of each agent, should be equal to each other
         self.assertEqual(
             self.env.agents[0].asset.state.time, self.env.agents[1].asset.state.time
@@ -52,15 +58,32 @@ class TestEnergyValleyEnv(unittest.TestCase):
         self.assertEqual(
             self.env.agents[0].asset.state.time, self.env.agents[2].asset.state.time
         )
+        self.assertEqual(
+            self.env.agents[0].asset.state.time, self.env.agents[3].asset.state.time
+        )
 
     def test_agent_configurations(self):
+        """
+        Test the configurations of the agents
+        """
         demand_agent = self.env.agents[0]
         solar_agent = self.env.agents[1]
         battery_agent = self.env.agents[2]
-
+        # Demand
         self.assertEqual(demand_agent.asset.name, "Demand")
         self.assertEqual(demand_agent.asset.max_power_in, float("inf"))
+        # Solar
         self.assertEqual(solar_agent.asset.name, "Solar")
         self.assertEqual(solar_agent.asset.max_power_out, float("inf"))
+        # Battery
         self.assertEqual(battery_agent.asset.name, "Battery")
         self.assertEqual(battery_agent.asset.energy_capacity, 1000)
+
+    def test_grid_configuration(self):
+        """
+        Separate test for the grid configuration
+        """
+        grid = self.env.agents[3]
+        self.assertEqual(grid.asset.name, "Grid_One")
+        self.assertEqual(grid.asset.max_power_in, 1000)
+        self.assertEqual(grid.asset.max_power_out, float("inf"))


### PR DESCRIPTION
Jira ticket link: https://repowerednl.atlassian.net/browse/REP-3343

Added the `Grid` in agents but not as `Agent`. Defaults to infinite `max_power_in` and `max_power_out` but is configurable in config (outside of the `agents` list in the config).