### PR TITLE
MAR-105 time and is_fcr should not be included in agent state

### DIFF
--- a/src/marloes/agents/base.py
+++ b/src/marloes/agents/base.py
@@ -83,6 +83,10 @@ class Agent(ABC):
                 start_idx:end_idx
             ]  # Numpy slicing is O(1)
 
+        # remove 'time' from the state since this is the same for all agents
+        if "time" in state:
+            state.pop("time")
+
         return state
 
     @abstractmethod

--- a/src/marloes/agents/battery.py
+++ b/src/marloes/agents/battery.py
@@ -59,6 +59,15 @@ class BatteryAgent(Agent):
         else:
             return self.asset.max_power_out * action
 
+    def get_state(self, start_idx):
+        """
+        Also removes the 'is_fcr' key from the state, since this is not relevant for this stage of MARLoes.
+        """
+        state = super().get_state(start_idx)
+        if "is_fcr" in state:
+            state.pop("is_fcr")
+        return state
+
     def observe(self):
         pass
 

--- a/src/marloes/agents/electrolyser.py
+++ b/src/marloes/agents/electrolyser.py
@@ -89,6 +89,15 @@ class ElectrolyserAgent(Agent):
         )
         self.asset.set_state(new_state)
 
+    def get_state(self, start_idx):
+        """
+        Also removes the 'is_fcr' key from the state, since this is not relevant for an Electrolyser.
+        """
+        state = super().get_state(start_idx)
+        if "is_fcr" in state:
+            state.pop("is_fcr")
+        return state
+
     def observe(self):
         pass
 

--- a/test/agents/test_battery.py
+++ b/test/agents/test_battery.py
@@ -72,6 +72,18 @@ class TestBatteryAgent(unittest.TestCase):
         self.assertEqual(self.battery_agent.map_action_to_setpoint(0.0), 0.0)
         self.assertEqual(self.battery_agent.map_action_to_setpoint(1.0), 40.0)
 
+    def test_get_state(self):
+        """
+        Tests whether the state without time or is_fcr is returned correctly.
+        """
+        state = self.battery_agent.get_state(0)
+        self.assertIn("power", state)
+        self.assertIn("state_of_charge", state)
+        self.assertIn("degradation", state)
+        self.assertNotIn("time", state)
+        self.assertNotIn("is_fcr", state)
+        self.assertEqual(len(state), 3)
+
     # General agent test
     @patch("simon.assets.battery.Battery.set_setpoint")
     def test_act_sets_correct_setpoint(self, mock_set_setpoint):

--- a/test/agents/test_electrolyser.py
+++ b/test/agents/test_electrolyser.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from freezegun import freeze_time
 from datetime import datetime, timedelta
 from simon.assets.battery import Battery
@@ -94,6 +94,18 @@ class TestElectrolyserAgent(unittest.TestCase):
                 self.assertEqual(
                     self.electrolyser_agent.map_action_to_setpoint(1.0), 40.0
                 )
+
+    def test_get_state(self):
+        """
+        Tests whether the state without time or is_fcr is returned correctly.
+        """
+        state = self.electrolyser_agent.get_state(0)
+        self.assertIn("power", state)
+        self.assertIn("state_of_charge", state)
+        self.assertIn("degradation", state)
+        self.assertNotIn("time", state)
+        self.assertNotIn("is_fcr", state)
+        self.assertEqual(len(state), 3)
 
     def test__loss_discharge(self):
         """

--- a/test/agents/test_solar.py
+++ b/test/agents/test_solar.py
@@ -111,3 +111,28 @@ class TestSolarAgentGetState(unittest.TestCase):
             state["forecast"], solar_agent.forecast[1400:1500]
         )
         self.assertEqual(state["mocked_state"], True)
+
+    @patch.object(
+        SolarAgent, "__init__", lambda self, *args, **kwargs: None
+    )  # Bypass init
+    def test_get_state(self):
+        """
+        Tests whether the state without time is returned correctly.
+        """
+        solar_agent = SolarAgent()
+        solar_agent.forecast = [1, 2, 3, 4, 5]
+        solar_agent.horizon = 2
+        # Mock asset state
+        solar_agent.asset = MagicMock()
+        solar_agent.asset.state.model_dump.return_value = {
+            "time": datetime.now(),
+            "power": 0.0,
+            "available_power": 0.0,
+        }
+
+        state = solar_agent.get_state(0)
+        self.assertIn("power", state)
+        self.assertIn("available_power", state)
+        self.assertIn("forecast", state)
+        self.assertNotIn("time", state)
+        self.assertEqual(len(state), 3)


### PR DESCRIPTION
## Description
Thought I'd do this real quick. 

## Jira Ticket
https://repowerednl.atlassian.net/browse/MAR-105

## Checks
- [x] I have added unit tests
- [ ] I have tested this locally
- [ ] Does this change introduce a significant decision? If yes, has an ADR been added or updated?
