### PR TITLE
MAR-85 battery parameters

### DIFF
--- a/docs/adr/0015-battery-parameters.md
+++ b/docs/adr/0015-battery-parameters.md
@@ -9,13 +9,14 @@ Accepted
 ## Context
 
 The default values for batteries are adapted from an actual battery that will be placed at the site in Alkmaar. (AC-coupled, ESS Liquid Cooling Cabinet - ESS-TRENE)
+The maximum efficiency of the battery was 0.98, but no information was provided about a general or mean efficiency. We used 0.90 instead which is a more accurate value.
 
 ## Decision
 
 The following values are added to the default config in `BatteryAgent`.
 - `max_power_in`: 125 kW
 - `max_power_out`: 125 kW
-- `efficiency`: 0.98
+- `efficiency`: 0.90
 - `total_cycles`: 8000
 The following were not found but are likely values:
 - `max_state_of_charge`: 0.95

--- a/src/marloes/agents/battery.py
+++ b/src/marloes/agents/battery.py
@@ -31,7 +31,7 @@ class BatteryAgent(Agent):
             "energy_capacity": config["energy_capacity"],
             "ramp_up_rate": 125,  # instant
             "ramp_down_rate": 125,  # instant
-            "efficiency": 0.98,
+            "efficiency": 0.90,
             "degradation_function": degradation_function,
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description
Just a few changes for the values, but added an ADR as well.
Got a bit confused when managing configs `power`, `max_power_in`, `max_power_out`, and ramp up/down rates. Does this make sense?

## Jira Ticket
https://repowerednl.atlassian.net/browse/MAR-85

## Checks
- [ ] I have added unit tests
- [ ] I have tested this locally
- [x] Does this change introduce a significant decision? If yes, has an ADR been added or updated?
